### PR TITLE
Feat/telemetry grouped counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,101 @@
+# e-ipfs-core-lib
+
+A library that collect utils and shared code for e-ipfs ecosystem.
+
+## Quickstart
+
+```
+npm i e-ipfs-core-lib
+```
+
+## Api
+
+### Telemetry
+#### Telemetry
+
+Create a telemetry manager that provide a [`prometheus`](https://github.com/prometheus) valid file [format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md) 
+
+Create metrics yaml configuration file:
+
+```yaml
+---
+component: bitswap-peer
+metrics:
+  bitswap-total-connections: BitSwap Total Connections
+  s3-request: AWS S3 requests
+  dynamo-request: AWS DynamoDB requests
+version: 0.1.0
+buildDate: "20220307.1423"
+```
+
+
+```javascript
+import path from 'path'
+import { Telemetry, dirname } from 'e-ipfs-core-lib'
+
+const configFile = path.join(dirname(import.meta.url), '../metrics.yml')
+const telemetry = new Telemetry({ configFile })
+telemetry.increaseCount('bitswap-total-connections', 2)
+
+const result = telemetry.export()
+console.log(result)
+```
+
+#### Telemetry instance methods
+* clear: Clear the metrics
+* createMetric(category, description, metric, type): Create a new metric
+  * category: String - The given name of the category
+  * description: String - The category description
+  * metric: METRIC_COUNT | METRIC_DURATIONS | METRIC_GROUPED_COUNT - The metric defined
+  * type: null | TYPE_GAUGE - The type of the metric. If not passed the value is defined based on the `metric` attribute. 
+* export: Export the metrics in `prometheus` format
+  ```
+    # HELP counter_grouped_count_total COUNTER (grouped-count)
+    # TYPE counter_grouped_count_total counter
+    counter_grouped_count_total{id="123"} 1 now
+    counter_grouped_count_total{id="456"} 2 now
+    ```
+* increaseCount(category, amount = 1): Increase the count for a category
+  * category: String - The given name of the category
+  * amount: Number (Default 1) - The amount to add to the metric
+* decreaseCount(category, amount = 1): Decrease the count for a category
+  * category: String - The given name of the category
+  * amount: Number (Default 1) - The amount to remove from the metric
+* increaseCountWithKey(category, key, amount = 1): Increase the count for a key in a category
+  * category: String - The given name of the category
+  * key: String - The key of the metric
+  * amount: Number (Default 1) - The amount to add to the metric
+* decreaseCountWithKey(category, key, amount = 1): Decrease the count for a key in a category
+  * category: String - The given name of the category
+  * key: String - The key of the metric
+  * amount: Number (Default 1) - The amount to remove from the metric
+* trackDuration(category, promise): Track the duration of an async call
+  * category: String - The given name of the category
+  * promise: Promise - The function to be tracked
+
+#### Metrics and types constants
+
+The constants below are exported
+
+* METRIC_COUNT
+* METRIC_DURATIONS
+* METRIC_GROUPED_COUNT
+* TYPE_COUNTER
+* TYPE_HISTOGRAM
+* TYPE_GAUGE
+
+### Utils
+#### dirname
+#### version
+#### cidToKey
+
+### AWS-Client
+#### createAwsClient,
+#### awsClientOptions,
+#### Client
+
+### Logger
+#### createLogger
+
+### Protocol
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e-ipfs-core-lib",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "E-IPFS core library",
   "license": "(Apache-2.0 AND MIT)",
   "homepage": "https://github.com/elastic-ipfs/core-lib",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": "18.12"
   },
   "dependencies": {
-    "@aws-sdk/util-dynamodb": "^3.216.0",
+    "@aws-sdk/util-dynamodb": "^3.218.0",
     "bl": "^6.0.0",
     "hdr-histogram-js": "^3.0.0",
     "js-yaml": "^4.1.0",
@@ -24,7 +24,7 @@
     "piscina": "^3.2.0",
     "protobufjs": "^7.1.2",
     "sodium-native": "^3.4.1",
-    "undici": "^5.12.0",
+    "undici": "^5.13.0",
     "xml-js": "^1.6.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e-ipfs-core-lib",
-  "version": "0.3.0",
+  "version": "0.3.0-beta-1",
   "description": "E-IPFS core library",
   "license": "(Apache-2.0 AND MIT)",
   "homepage": "https://github.com/elastic-ipfs/core-lib",

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -4,6 +4,10 @@ import * as hdr from 'hdr-histogram-js'
 
 const PERCENTILES = [0.001, 0.01, 0.1, 1, 2.5, 10, 25, 50, 75, 90, 97.5, 99, 99.9, 99.99, 99.999]
 
+const METRIC_GROUPED_COUNT = 'grouped-count'
+const METRIC_DURATIONS = 'durations'
+const METRIC_COUNT = 'count'
+
 class Aggregator {
   constructor (category, description, metric, type) {
     this.tag = `${category}-${metric}`
@@ -13,12 +17,12 @@ class Aggregator {
     // type is optional
     if (!type) {
       // set the type by the metric
-      if (metric === 'durations') {
+      if (metric === METRIC_DURATIONS) {
         this.type = 'histogram'
       } else {
         this.type = 'counter'
         this.exportName += '_total'
-        this.isGrouped = metric === 'grouped-count'
+        this.isGrouped = metric === METRIC_GROUPED_COUNT
       }
     } else {
       this.type = type
@@ -110,9 +114,9 @@ class Telemetry {
       // Create metrics
       this.metrics = new Map()
       for (const [category, description] of Object.entries(metrics)) {
-        this.createMetric(category, description, 'count')
-        this.createMetric(category, description, 'groupedCount')
-        this.createMetric(category, description, 'durations')
+        this.createMetric(category, description, METRIC_COUNT)
+        this.createMetric(category, description, METRIC_GROUPED_COUNT)
+        this.createMetric(category, description, METRIC_DURATIONS)
       }
     } catch (err) {
       logger.error({ err }, 'error in telemetry constructor')
@@ -178,27 +182,27 @@ class Telemetry {
   }
 
   increaseCount (category, amount = 1) {
-    const metric = this.ensureMetric(category, 'count')
+    const metric = this.ensureMetric(category, METRIC_COUNT)
     metric.record(amount)
   }
 
   decreaseCount (category, amount = 1) {
-    const metric = this.ensureMetric(category, 'count')
+    const metric = this.ensureMetric(category, METRIC_COUNT)
     metric.record(-1 * amount)
   }
 
   increaseCountWithKey (category, key, amount = 1) {
-    const metric = this.ensureMetric(category, 'grouped-count')
+    const metric = this.ensureMetric(category, METRIC_GROUPED_COUNT)
     metric.recordWithKey(key, amount)
   }
 
   decreaseCountWithKey (category, key, amount = 1) {
-    const metric = this.ensureMetric(category, 'grouped-count')
+    const metric = this.ensureMetric(category, METRIC_GROUPED_COUNT)
     metric.recordWithKey(key, -1 * amount)
   }
 
   async trackDuration (category, promise) {
-    const metric = this.ensureMetric(category, 'durations')
+    const metric = this.ensureMetric(category, METRIC_DURATIONS)
     const startTime = process.hrtime.bigint()
 
     try {
@@ -209,4 +213,4 @@ class Telemetry {
   }
 }
 
-export { Telemetry }
+export { Telemetry, METRIC_COUNT, METRIC_DURATIONS, METRIC_GROUPED_COUNT }

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -67,7 +67,7 @@ class Aggregator {
     const value = {
       empty: (this.type === 'histogram' && count === 0) ||
         ((this.type === 'counter' && !this.isGrouped) && this.sum === 0) ||
-        ((this.type === 'counter' && this.isGrouped) && Object.keys(this.groupedSum) === 0),
+        ((this.type === 'counter' && this.isGrouped) && Object.keys(this.groupedSum).length === 0),
       sum: this.sum,
       isGrouped: this.isGrouped,
       groupedSum: this.groupedSum,

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -2,7 +2,7 @@
 import path from 'path'
 import t from 'tap'
 import dedent from 'dedent'
-import { Telemetry, dirname, METRIC_GROUPED_COUNT, METRIC_DURATIONS, METRIC_COUNT } from '../src/index.js'
+import { Telemetry, dirname, METRIC_GROUPED_COUNT, METRIC_DURATIONS, METRIC_COUNT, TYPE_GAUGE } from '../src/index.js'
 import * as helper from './helper/index.js'
 
 // process.env.NOW = 'now'
@@ -168,7 +168,7 @@ t.test('Telemetry', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
       telemetry.createMetric('c1', 'COUNTER', METRIC_DURATIONS)
-      telemetry.createMetric('c2', 'GAUGE', METRIC_COUNT, 'gauge')
+      telemetry.createMetric('c2', 'GAUGE', METRIC_COUNT, TYPE_GAUGE)
       telemetry.createMetric('c3', 'HISTOGRAM', METRIC_DURATIONS)
 
       t.equal(telemetry.export(), dedent`
@@ -182,7 +182,7 @@ t.test('Telemetry', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
       telemetry.createMetric('c1', 'COUNTER', METRIC_COUNT)
-      telemetry.createMetric('c2', 'GAUGE', METRIC_COUNT, 'gauge')
+      telemetry.createMetric('c2', 'GAUGE', METRIC_COUNT, TYPE_GAUGE)
       telemetry.createMetric('c3', 'HISTOGRAM', METRIC_DURATIONS)
 
       telemetry.increaseCount('c1', 1)

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -2,7 +2,7 @@
 import path from 'path'
 import t from 'tap'
 import dedent from 'dedent'
-import { Telemetry, dirname } from '../src/index.js'
+import { Telemetry, dirname, METRIC_GROUPED_COUNT, METRIC_DURATIONS, METRIC_COUNT } from '../src/index.js'
 import * as helper from './helper/index.js'
 
 // process.env.NOW = 'now'
@@ -49,7 +49,7 @@ t.test('Telemetry', async t => {
     t.test('should increase the count of a metric', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
-      telemetry.createMetric('counter', 'COUNTER', 'count')
+      telemetry.createMetric('counter', 'COUNTER', METRIC_COUNT)
 
       telemetry.increaseCount('counter')
 
@@ -69,7 +69,7 @@ t.test('Telemetry', async t => {
     t.test('should decrease the count of a metric', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
-      telemetry.createMetric('counter', 'COUNTER', 'count')
+      telemetry.createMetric('counter', 'COUNTER', METRIC_COUNT)
 
       telemetry.decreaseCount('counter')
 
@@ -89,7 +89,7 @@ t.test('Telemetry', async t => {
     t.test('should track a function', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
-      telemetry.createMetric('tracking1', 'GAUGE', 'durations')
+      telemetry.createMetric('tracking1', 'GAUGE', METRIC_DURATIONS)
 
       await telemetry.trackDuration('tracking1', async () => { return 1 })
 
@@ -127,7 +127,7 @@ t.test('Telemetry', async t => {
     t.test('should handle a failing function', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
-      telemetry.createMetric('trackingboom', 'HISTOGRAM', 'durations')
+      telemetry.createMetric('trackingboom', 'HISTOGRAM', METRIC_DURATIONS)
 
       await telemetry.trackDuration('trackingboom', async () => { throw new Error('BOOM') })
 
@@ -167,9 +167,9 @@ t.test('Telemetry', async t => {
     t.test('should get the metrics result with registered metrics', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
-      telemetry.createMetric('c1', 'COUNTER', 'durations')
-      telemetry.createMetric('c2', 'GAUGE', 'count', 'gauge')
-      telemetry.createMetric('c3', 'HISTOGRAM', 'durations')
+      telemetry.createMetric('c1', 'COUNTER', METRIC_DURATIONS)
+      telemetry.createMetric('c2', 'GAUGE', METRIC_COUNT, 'gauge')
+      telemetry.createMetric('c3', 'HISTOGRAM', METRIC_DURATIONS)
 
       t.equal(telemetry.export(), dedent`
       # HELP c2_count GAUGE (count)
@@ -181,13 +181,13 @@ t.test('Telemetry', async t => {
     t.test('should get the metrics result with registered metrics and values', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
-      telemetry.createMetric('c1', 'COUNTER', 'count')
-      telemetry.createMetric('c2', 'GAUGE', 'count', 'gauge')
-      telemetry.createMetric('c3', 'HISTOGRAM', 'durations')
+      telemetry.createMetric('c1', 'COUNTER', METRIC_COUNT)
+      telemetry.createMetric('c2', 'GAUGE', METRIC_COUNT, 'gauge')
+      telemetry.createMetric('c3', 'HISTOGRAM', METRIC_DURATIONS)
 
       telemetry.increaseCount('c1', 1)
       telemetry.increaseCount('c2', 2)
-      telemetry.ensureMetric('c3', 'durations').record(3)
+      telemetry.ensureMetric('c3', METRIC_DURATIONS).record(3)
 
       t.equal(telemetry.export(), dedent`
       # HELP c1_count_total COUNTER (count)
@@ -223,7 +223,7 @@ t.test('Telemetry', async t => {
     t.test('should increase the count of a metric', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
-      telemetry.createMetric('counter', 'COUNTER', 'grouped-count')
+      telemetry.createMetric('counter', 'COUNTER', METRIC_GROUPED_COUNT)
 
       telemetry.increaseCountWithKey('counter', '{id="123"}')
       telemetry.increaseCountWithKey('counter', '{id="456"}')
@@ -248,7 +248,7 @@ t.test('Telemetry', async t => {
     t.test('should increase the count of a metric', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
-      telemetry.createMetric('counter', 'COUNTER', 'grouped-count')
+      telemetry.createMetric('counter', 'COUNTER', METRIC_GROUPED_COUNT)
 
       telemetry.increaseCountWithKey('counter', '{id="123"}')
       telemetry.increaseCountWithKey('counter', '{id="456"}')

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -218,4 +218,56 @@ t.test('Telemetry', async t => {
       )
     })
   })
+
+  t.test('increaseCount withKey', async t => {
+    t.test('should increase the count of a metric', async t => {
+      const telemetry = new Telemetry({ configFile, logger })
+      telemetry.clear()
+      telemetry.createMetric('counter', 'COUNTER', 'grouped-count')
+
+      telemetry.increaseCountWithKey('counter', '{id="123"}')
+      telemetry.increaseCountWithKey('counter', '{id="456"}')
+      telemetry.increaseCountWithKey('counter', '{id="123"}')
+      telemetry.increaseCountWithKey('counter', '{id="456"}')
+      telemetry.increaseCountWithKey('counter', '{id="123"}')
+
+      t.equal(telemetry.export(), dedent`
+      # HELP counter_grouped_count_total COUNTER (grouped-count)
+      # TYPE counter_grouped_count_total counter
+      counter_grouped_count_total{id="123"} 3 now
+      counter_grouped_count_total{id="456"} 2 now`)
+    })
+
+    t.test('all metrics should be defined in the config file', async t => {
+      const telemetry = new Telemetry({ configFile, logger })
+      t.throws(() => telemetry.increaseCountWithKey('unknown'), { message: 'Metric unknown not found' })
+    })
+  })
+
+  t.test('decrease withKey', async t => {
+    t.test('should increase the count of a metric', async t => {
+      const telemetry = new Telemetry({ configFile, logger })
+      telemetry.clear()
+      telemetry.createMetric('counter', 'COUNTER', 'grouped-count')
+
+      telemetry.increaseCountWithKey('counter', '{id="123"}')
+      telemetry.increaseCountWithKey('counter', '{id="456"}')
+      telemetry.increaseCountWithKey('counter', '{id="123"}')
+      telemetry.increaseCountWithKey('counter', '{id="456"}')
+      telemetry.increaseCountWithKey('counter', '{id="123"}')
+      telemetry.decreaseCountWithKey('counter', '{id="123"}')
+      telemetry.decreaseCountWithKey('counter', '{id="123"}')
+
+      t.equal(telemetry.export(), dedent`
+      # HELP counter_grouped_count_total COUNTER (grouped-count)
+      # TYPE counter_grouped_count_total counter
+      counter_grouped_count_total{id="123"} 1 now
+      counter_grouped_count_total{id="456"} 2 now`)
+    })
+
+    t.test('all metrics should be defined in the config file', async t => {
+      const telemetry = new Telemetry({ configFile, logger })
+      t.throws(() => telemetry.increaseCountWithKey('unknown'), { message: 'Metric unknown not found' })
+    })
+  })
 })

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -219,7 +219,7 @@ t.test('Telemetry', async t => {
     })
   })
 
-  t.test('increaseCount withKey', async t => {
+  t.test('increase grouped count', async t => {
     t.test('should increase the count of a metric', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()
@@ -246,7 +246,7 @@ t.test('Telemetry', async t => {
     })
   })
 
-  t.test('decrease withKey', async t => {
+  t.test('decrease grouped count', async t => {
     t.test('should increase the count of a metric', async t => {
       const telemetry = new Telemetry({ configFile, logger })
       telemetry.clear()

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -236,6 +236,8 @@ t.test('Telemetry', async t => {
       # TYPE counter_grouped_count_total counter
       counter_grouped_count_total{id="123"} 3 now
       counter_grouped_count_total{id="456"} 2 now`)
+
+      t.equal(telemetry.export(), dedent`# no registered metrics`)
     })
 
     t.test('all metrics should be defined in the config file', async t => {
@@ -263,6 +265,8 @@ t.test('Telemetry', async t => {
       # TYPE counter_grouped_count_total counter
       counter_grouped_count_total{id="123"} 1 now
       counter_grouped_count_total{id="456"} 2 now`)
+
+      t.equal(telemetry.export(), dedent`# no registered metrics`)
     })
 
     t.test('all metrics should be defined in the config file', async t => {


### PR DESCRIPTION
Add a metric of type GROUPED_COUNT

```
      telemetry.createMetric('counter', 'COUNTER', METRIC_GROUPED_COUNT)
```

That can be updated using:

```
telemetry.increaseCountWithKey('counter', '{id="123"}')
telemetry.decreaseCountWithKey('counter', '{id="123"}')
```

end exports:

```
     # HELP counter_grouped_count_total COUNTER (grouped-count)
      # TYPE counter_grouped_count_total counter
      counter_grouped_count_total{id="123"} 1 now
      counter_grouped_count_total{id="456"} 2 now
```